### PR TITLE
Fix method name in tests

### DIFF
--- a/test/test.index.js
+++ b/test/test.index.js
@@ -253,7 +253,7 @@ test('API: remove highlighted cells', (assert) => {
     const $cell = d.getCell(0, 0);
     assert.true($cell.classList.contains('cookie'));
 
-    d.clearHighlightedCell();
+    d.clearHighlightedCells();
     assert.false($cell.classList.contains('cookie'));
 });
 


### PR DESCRIPTION
One of the tests was calling `clearHighlightedCell` instead of `clearHighlightedCells`.